### PR TITLE
BUG - Never delete users so they can be used for stats and avatars

### DIFF
--- a/models/Game.js
+++ b/models/Game.js
@@ -131,7 +131,7 @@ class Game {
     const user = this.players.all[userId];
     this.trigger('playerLeave', 'playerLeave', this, user);
     this.players.byId.splice(this.players.byId.indexOf(userId), 1);
-    delete this.players.all[userId];
+    // delete this.players.all[userId];
     this.updateOpenSeats();
     if (this.players.byId.length < settings.minPlayers) {
       this.active = false;
@@ -145,7 +145,9 @@ class Game {
    */
   addPlayer(user) {
     if (this.players.byId.length < settings.maxPlayers) {
-      this.players.byId.push(user.userId);
+      if (this.players.byId.indexOf(user.userId) < 0) {
+        this.players.byId.push(user.userId);
+      }
       this.players.all[user.userId] = user.summary();
     } else {
       console.log('Error: Game full');

--- a/spec/gameModelTests.js
+++ b/spec/gameModelTests.js
@@ -34,7 +34,7 @@ describe('Game model', () => {
     expect(game.trigger.calls.all().filter((call) => call.args[0] === 'playerChange')).toBeTruthy();
     expect(game.trigger.calls.all().filter((call) => call.args[0] === 'empty')).toBeTruthy();
     expect(game.seatsOpen).toBe(maxSeats);
-    expect(game.players.all['1']).toBeUndefined();
+    expect(game.players.byId.indexOf('1')).toBe(-1);
     expect(game.players.byId.length).toBe(0);
   });
   it('should get a prompt with getPrompt', () => {


### PR DESCRIPTION
<!--- Keep this line &  above for command line hub users -->
## Description

<!--- Describe your changes in detail -->

There has been an error where the app crashes when looking for users that
are no longer in the store.  This keeps them in the store forever
## Related Issue(s)

<!--- Please link to the issue here using 'closing' or 'connected': -->

Closes smileguess/smileguess#200
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes and any tests you've written. -->

Manually
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Major refactor (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (Check this if you changed any documentation at all)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have rebased and squashed my commits.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
