### PR TITLE
FEAT - Remove toast for player join/leave events

### DIFF
--- a/controllers/GameController.js
+++ b/controllers/GameController.js
@@ -91,11 +91,14 @@ const play = (games, callback) => {
       .on('newPrompt', disseminateChange)
       .on('newDealer',
         disseminateChange,
-        (type, game, user) => sendMemoAndSystemMessage(game, `${user.username} is the new dealer`, games.messages))
+        (type, game, user) => sendSystemMessage(game, `${user.username} is the new dealer`, games.messages))
       .on('playerChange', disseminateChange)
-      .on('playerLeave', (type, game, user) => sendMemoAndSystemMessage(game, `${user.username} has left the game`, games.messages))
-      .on('playerJoin', (type, game, user) => sendMemoAndSystemMessage(game, `${user.username} has joined the game`, games.messages))
-      .on('playerWon', (type, game, user) => sendMemoAndSystemMessage(game, `${user.username} has won the game!`, games.messages));
+      .on('playerLeave', (type, game, user) => sendSystemMessage(game, `${user.username} has left the game`, games.messages))
+      .on('playerJoin', (type, game, user) => sendSystemMessage(game, `${user.username} has joined the game`, games.messages))
+      .on('playerWon', (type, game, user) => { 
+        sendMemoAndSystemMessage(game, `${user.username} has won the game!`, games.messages);
+        sendSystemMessage(game, `The answer was "${game.prompt.forDisplay}"`, games.messages);
+      });
   } else {
     game = games.getNextOpenGame();
   }

--- a/spec/userControllerTests.js
+++ b/spec/userControllerTests.js
@@ -1,24 +1,24 @@
 const express = require('express');
 const Users = require('../collections/Users');
 const UserController = require('../controllers/UserController');
-const ioCreate = require('socket.io');
-const app = express();
-const server = require('http').createServer(app);
-const io = ioCreate.listen(server);
-const onConnect = require('../sockets/onConnect');
-const onDisconnect = require('../sockets/onDisconnect');
+// const ioCreate = require('socket.io');
+// const app = express();
+// const server = require('http').createServer(app);
+// const io = ioCreate.listen(server);
+// const onConnect = require('../sockets/onConnect');
+// const onDisconnect = require('../sockets/onDisconnect');
 
 describe('User controller', () => {
   const users = new Users();
   const testUser = UserController.create({ params: 'anotherDeviceId' }, null, users);
-  let socket;
-  io.on('connection', (socket) => {
-    onConnect(io, socket);
-    socket = socket;
-    socket.on('disconnect', () => {
-      onDisconnect(io, socket);
-    });
-  });
+  const db = {
+    users,
+  };
+
+  // Mock socket connection object
+  let mockSocket = {
+    id: 'SomeFakeSocketID'
+  };
   it('should create users', () => {
     // this test user was created without making an API call
     // instantiation through an API call is tested in basicServerTests.js
@@ -26,7 +26,7 @@ describe('User controller', () => {
   });
   it('should impart users with a socket connection object', () => {
     expect(testUser.socket).toBe(null);
-    UserController.connect(testUser, socket);
+    UserController.connect(db, testUser, mockSocket);
     expect(testUser.socket).not.toBe(null);
   });
   it('should get users', () => {


### PR DESCRIPTION
<!--- Keep this line &  above for command line hub users -->
## Description

<!--- Describe your changes in detail -->

This removes the toast for when a player joins and leaves and fixes a small
problem with the userController test.
## Related Issue(s)

<!--- Please link to the issue here using 'closing' or 'connected': -->

Closes smileguess/smileguess#206
Closes smileguess/smileguess#212
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes and any tests you've written. -->

Manual testing and jasmine
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Major refactor (fix or feature that would cause existing functionality to change)
- [ ] Documentation change (Check this if you changed any documentation at all)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] My code follows the code style of this project.
- [x] I have rebased and squashed my commits.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My change requires a change to the documentation.
